### PR TITLE
Develop

### DIFF
--- a/FULLSTACKFURY.EduSpace.API/Program.cs
+++ b/FULLSTACKFURY.EduSpace.API/Program.cs
@@ -71,10 +71,7 @@ builder.Services.AddCors(options =>
     options.AddPolicy("ProductionPolicy",
         policy =>
         {
-            policy.WithOrigins(
-                    "https://eduspacewebapp.netlify.app",
-                    "https://eduspace-frontend-web-app-production.up.railway.app"
-                    ) 
+            policy.WithOrigins("https://eduspacewebapp.netlify.app") 
                 .AllowAnyHeader()
                 .AllowAnyMethod()
                 .AllowCredentials();
@@ -244,8 +241,14 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-// Use the CORS policy
-app.UseCors("AllowFrontend");
+if (app.Environment.IsDevelopment())
+{
+    app.UseCors("DevelopmentPolicy");
+}
+else
+{
+    app.UseCors("ProductionPolicy");
+}
 
 app.UseAuthorization();
 

--- a/FULLSTACKFURY.EduSpace.API/Program.cs
+++ b/FULLSTACKFURY.EduSpace.API/Program.cs
@@ -71,7 +71,8 @@ builder.Services.AddCors(options =>
     options.AddPolicy("AllowFrontend",
         policyBuilder => policyBuilder
             .WithOrigins("https://localhost:7238",
-                "https://eduspacewebapp.netlify.app")// Your frontend URL
+                "https://eduspacewebapp.netlify.app",
+                "https://eduspace-frontend-web-app-production.up.railway.app")// Yours frontend URL
             .AllowAnyHeader()
             .AllowAnyMethod()
             .AllowCredentials());

--- a/FULLSTACKFURY.EduSpace.API/Program.cs
+++ b/FULLSTACKFURY.EduSpace.API/Program.cs
@@ -68,17 +68,27 @@ builder.Services.AddControllers();
 
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy("AllowFrontend",
-        policyBuilder => policyBuilder
-            .WithOrigins("https://localhost:7238",
-                "https://eduspacewebapp.netlify.app",
-                "https://eduspace-frontend-web-app-production.up.railway.app")// Yours frontend URL
-            .AllowAnyHeader()
-            .AllowAnyMethod()
-            .AllowCredentials());
+    options.AddPolicy("ProductionPolicy",
+        policy =>
+        {
+            policy.WithOrigins(
+                    "https://eduspacewebapp.netlify.app",
+                    "https://eduspace-frontend-web-app-production.up.railway.app"
+                    ) 
+                .AllowAnyHeader()
+                .AllowAnyMethod()
+                .AllowCredentials();
+        });
+
+    options.AddPolicy("DevelopmentPolicy",
+        policy =>
+        {
+            policy.WithOrigins("http://localhost:5173") 
+                .AllowAnyHeader()
+                .AllowAnyMethod()
+                .AllowCredentials();
+        });
 });
-
-
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(


### PR DESCRIPTION
This pull request updates the CORS configuration in `Program.cs` to better separate development and production environments. Instead of a single policy for all environments, there are now distinct policies for development and production, each with its own allowed origins.

**CORS policy improvements:**

* Added two separate CORS policies: `ProductionPolicy` (allowing only `https://eduspacewebapp.netlify.app`) and `DevelopmentPolicy` (allowing only `http://localhost:5173`), replacing the previous single `AllowFrontend` policy.
* Updated CORS middleware usage so that the appropriate policy is applied based on the environment—`DevelopmentPolicy` for development and `ProductionPolicy` for production.